### PR TITLE
Check content of $Location

### DIFF
--- a/tf.ps1
+++ b/tf.ps1
@@ -117,6 +117,16 @@ if ($UtilResourceGroupName -eq "") {
     $UtilResourceGroupName = "$($Prefix)_$($EnvironmentName)_util_rg".ToLower()
 }
 
+# Check Location parameter to avoid Error:
+#The specified location '/home/vsts/work/1/s' is invalid. A location must consist of characters, whitespace, digit, or following symbols '(,)'.
+$CurrentLocation = get-location
+Write-Verbose "Current working location: $CurrentLocation"
+if ($Location -match $CurrentLocation)
+{
+    Write-Warning "Found un-expected content in -Location: $Location . Fallback to 'westeurope'"
+    $Location = "westeurope"
+}
+
 $Location = $Location.ToLower()
 $Location = $Location -Replace " "
 

--- a/tf.ps1
+++ b/tf.ps1
@@ -420,7 +420,7 @@ function LockdownTerraformBackend {
     Write-Verbose "[Terraform State] Rewriting network rules..."
     foreach ($ipRule in $existingNetworkRulesResponse.ipRules) {
         Write-Verbose "[Terraform State] Dropping $($ipRule.ipAddressOrRange)"
-        az storage account network-rule remove --resource-group $UtilResourceGroupName --account-name $Location --ip-address $ipRule.ipAddressOrRange --output none
+        az storage account network-rule remove --resource-group $UtilResourceGroupName --account-name $global:TfStateStorageAccountName --ip-address $ipRule.ipAddressOrRange --output none
         if ($LastExitCode -gt 0) { throw "az CLI error." }
     }
 


### PR DESCRIPTION
Check content of $Location to avoid Error:
The specified location '/home/vsts/work/1/s' is invalid. A location must consist of characters, whitespace, digit, or following symbols '(,)'.