### PR TITLE
Use Blob V2 for state files and deactviate public blob access

### DIFF
--- a/tf.ps1
+++ b/tf.ps1
@@ -888,11 +888,12 @@ function CreateOrUpdateTerraformBackend {
    Start-NativeExecution { az storage account create --name $global:TfStateStorageAccountName `
         --resource-group $UtilResourceGroupName `
         --location $Location --sku "Standard_LRS" `
-        --kind "BlobStorage" --access-tier "Hot" `
+        --kind "StorageV2" --access-tier "Hot" `
         --encryption-service "blob" `
         --encryption-service "file" `
         --https-only "true" `
         --default-action "Allow" `
+        --allow-blob-public-access "false" `
         --bypass "None" `
         --output none `
         --tags "environment=$EnvironmentName" "purpose=TerraformStateStorage" "prefix=$Prefix" }


### PR DESCRIPTION
In order to comply with security recommendations from Azure Defender in China I wanted to update the storage account holding the terraform state files from v1 to v2. These little changes make the taskrunner compatible with v2.